### PR TITLE
fix: exclude zuii from Changesets publish via private field

### DIFF
--- a/.github/workflows/root-version-bump.yml
+++ b/.github/workflows/root-version-bump.yml
@@ -71,4 +71,6 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish zuii
-        run: npm publish --access public
+        run: |
+          npm pkg delete private
+          npm publish --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "zuii",
 	"version": "1.7.2",
+	"private": true,
 	"packageManager": "pnpm@9.9.0",
 	"description": "Bibliothèque de composants UI légère, intuitive et modulaire pour les interfaces web modernes.",
 	"type": "module",


### PR DESCRIPTION
Le champ ignore de Changesets ne bloquait que le versioning, pas la tentative de publish du package racine zuii, causant un échec systématique du workflow Release (2FA/token). Ajout de private:true pour l'exclure proprement, retiré à la volée dans Root Version Bump avant npm publish (OIDC).